### PR TITLE
Panel de usuarios duplicados, cambio reporte general-registro academico

### DIFF
--- a/back-end/modulo_admin/views.py
+++ b/back-end/modulo_admin/views.py
@@ -18,7 +18,7 @@ from modulo_asignacion.models import asignacion
 from django.shortcuts import get_object_or_404
 
 
-from django.db.models import Prefetch
+from django.db.models import Prefetch, Count, F, Window
 from rest_framework.response import Response
 from rest_framework import status
 from modulo_geografico.models import municipio
@@ -391,67 +391,86 @@ class panel_admin_usuario_viewset(viewsets.ViewSet):
             return Response({"error": str(e)}, status=status.HTTP_400_BAD_REQUEST)
 
     """
-    Elimina un usuario existente y activo en el sistema.
+    Elimina un usuario existente y activo en el sistema. (Usado únicamente para usuarios duplicados)
     """
     @action(detail=False, methods=['post'], url_path='eliminar_usuario', permission_classes=[IsAuthenticated])
     def eliminar_usuario(self, request, pk=None):
-        """
-        Elimina un usuario existente en el sistema.
-        """
-        """
-        {
-            "usuario": "123456789",
-        }
-        """
-        # WIP
-        try:
-            semestres_activos = semestre.objects.filter(semestre_actual=True).values_list('id', flat=True)
-        except Exception as e:
-            return Response({"error": str(e)}, status=status.HTTP_400_BAD_REQUEST)
-        
-        try:
-            asignaciones_usuario = asignacion.objects.filter(
-                id_usuario__username=request.data['usuario'])
-            if asignaciones_usuario.exists():
-                if asignaciones_usuario.filter(id_semestre__in=semestres_activos).exists():
-                    return Response({"error": "No se puede eliminar el usuario porque tiene asignaciones activas en el semestre actual."}, status=status.HTTP_400_BAD_REQUEST)
-                else:
-                    id_user = asignaciones_usuario['id_usuario']
-                    
-        except Exception as e:
-            return Response({"error": str(e)}, status=status.HTTP_400_BAD_REQUEST)
-
 
         try:
-            usuarios_data = request.data  # Lista de diccionarios con clave "usuario"
-
-            if not isinstance(usuarios_data, list) or not usuarios_data:
+            ids = request.data.get('ids', [])
+            # print("DATA:", request.data)
+            # print("IDS:", ids)
+            if not isinstance(ids, list) or not ids:
                 return Response(
-                    {"error": "Debes proporcionar una lista de usuarios válida."},
+                    {"error": "Debes enviar una lista de IDs válida."},
                     status=status.HTTP_400_BAD_REQUEST
                 )
 
-            mensajes = []
-
             with transaction.atomic():
-                for item in usuarios_data:
-                    username = item.get("usuario")
-                    if not username:
-                        mensajes.append(
-                            {"usuario": None, "error": "Falta el campo 'usuario'"})
-                        continue
+                usuarios = User.objects.annotate(
+                    total_asignaciones=Count(
+                        'id_creador_seguimiento', distinct=True)
+                ).filter(id__in=ids).distinct()
 
-                    try:
-                        user = User.objects.get(username=username)
-                        user.delete()
-                        mensajes.append(
-                            {"usuario": username, "mensaje": "Eliminado exitosamente"})
+                eliminados = []
+                bloqueados = []
 
-                    except User.DoesNotExist:
-                        mensajes.append(
-                            {"usuario": username, "error": "Usuario no encontrado"})
+                for user in usuarios:
+                    if user.total_asignaciones > 0:
+                        bloqueados.append({
+                            "id": user.id,
+                            "username": user.username,
+                            "total_asignaciones": user.total_asignaciones,
+                            "error": "Tiene asignaciones, no se puede eliminar"
+                        })
+                    else:
+                        eliminados.append({
+                            "id": user.id,
+                            "username": user.username
+                        })
 
-            return Response(mensajes, status=status.HTTP_200_OK)
+                # eliminar solo los que sí se pueden
+                ids_eliminar = [u["id"] for u in eliminados]
+
+                User.objects.filter(id__in=ids_eliminar).delete()
+
+            return Response({
+                "eliminados": eliminados,
+                "bloqueados": bloqueados,
+                "total_eliminados": len(eliminados),
+                "total_bloqueados": len(bloqueados)
+            }, status=status.HTTP_200_OK)
+
+        except Exception as e:
+            return Response({"error": str(e)}, status=status.HTTP_400_BAD_REQUEST)
+
+    """
+    Listar usuarios duplicados por nombre y apellido, junto con la cantidad de seguimientos que tienen cada uno.
+    """
+    @action(detail=False, methods=['post'], url_path='listar_usuarios_duplicados',
+            permission_classes=[IsAuthenticated]
+            )
+    def listar_usuarios_duplicados(self, request, pk=None):
+        try:
+            usuarios = User.objects.annotate(
+                duplicados=Window(
+                    expression=Count('id'),
+                    partition_by=[F('first_name'), F('last_name')]
+                ),
+                total_asignaciones=Count(
+                    'id_creador_seguimiento', distinct=True)
+            ).filter(
+                duplicados__gt=1
+            ).values(
+                'id',
+                'username',
+                'first_name',
+                'last_name',
+                'email',
+                'total_asignaciones'
+            ).order_by('first_name', 'last_name')
+
+            return Response(list(usuarios), status=status.HTTP_200_OK)
 
         except Exception as e:
             return Response({"error": str(e)}, status=status.HTTP_400_BAD_REQUEST)

--- a/back-end/modulo_reportes/views.py
+++ b/back-end/modulo_reportes/views.py
@@ -13,7 +13,7 @@ from modulo_usuario_rol.models import rol, usuario_rol, estudiante, cond_excepci
 from modulo_asignacion.models import asignacion
 from modulo_instancia.models import semestre, sede
 from modulo_programa.models import dir_programa, facultad, programa, programa_estudiante, estado_programa, vcd_academico
-from modulo_seguimiento.models import inasistencia, seguimiento_individual, riesgo_individual 
+from modulo_seguimiento.models import inasistencia, seguimiento_individual, riesgo_individual
 from modulo_academico.models import monitoria_academica, materia
 from modulo_formularios_externos.models import asistencia as asistencia_model
 from datetime import datetime, timedelta, date
@@ -44,60 +44,90 @@ class estudiante_por_rol_viewsets(viewsets.ModelViewSet):
 
         if data_usuario_rol == "monitor":
 
-            list_id_estudiantes = asignacion.objects.filter(id_usuario=pk, id_semestre=var_semestre.id, estado=True).values('id_estudiante')
-            list_estudiantes = estudiante.objects.filter(id__in=list_id_estudiantes)
-            serializer_estudiantes = estudiante_serializer(list_estudiantes, many=True)
+            list_id_estudiantes = asignacion.objects.filter(
+                id_usuario=pk, id_semestre=var_semestre.id, estado=True).values('id_estudiante')
+            list_estudiantes = estudiante.objects.filter(
+                id__in=list_id_estudiantes)
+            serializer_estudiantes = estudiante_serializer(
+                list_estudiantes, many=True)
             return Response(serializer_estudiantes.data)
 
         elif data_usuario_rol == "practicante":
-            list_id_monitores= usuario_rol.objects.filter(id_jefe=pk, id_semestre=var_semestre.id, estado="ACTIVO").values('id_usuario')
-            list_id_estudiantes = asignacion.objects.filter(id_usuario__in=list_id_monitores, id_semestre=var_semestre.id, estado=True).values('id_estudiante')
-            list_estudiantes = estudiante.objects.filter(id__in=list_id_estudiantes)
-            serializer_estudiantes = estudiante_serializer(list_estudiantes, many=True)
+            list_id_monitores = usuario_rol.objects.filter(
+                id_jefe=pk, id_semestre=var_semestre.id, estado="ACTIVO").values('id_usuario')
+            list_id_estudiantes = asignacion.objects.filter(
+                id_usuario__in=list_id_monitores, id_semestre=var_semestre.id, estado=True).values('id_estudiante')
+            list_estudiantes = estudiante.objects.filter(
+                id__in=list_id_estudiantes)
+            serializer_estudiantes = estudiante_serializer(
+                list_estudiantes, many=True)
             return Response(serializer_estudiantes.data)
         elif data_usuario_rol == "profesional":
-            list_id_practicantes= usuario_rol.objects.filter(id_jefe=pk, id_semestre=var_semestre.id, estado="ACTIVO").values('id_usuario')
-            list_id_monitores= usuario_rol.objects.filter(id_jefe__in=list_id_practicantes, id_semestre=var_semestre.id, estado="ACTIVO").values('id_usuario')
-            list_id_estudiantes = asignacion.objects.filter(id_usuario__in=list_id_monitores, id_semestre=var_semestre.id, estado=True).values('id_estudiante')
-            list_estudiantes = estudiante.objects.filter(id__in=list_id_estudiantes)
-            serializer_estudiantes = estudiante_serializer(list_estudiantes, many=True)
+            list_id_practicantes = usuario_rol.objects.filter(
+                id_jefe=pk, id_semestre=var_semestre.id, estado="ACTIVO").values('id_usuario')
+            list_id_monitores = usuario_rol.objects.filter(
+                id_jefe__in=list_id_practicantes, id_semestre=var_semestre.id, estado="ACTIVO").values('id_usuario')
+            list_id_estudiantes = asignacion.objects.filter(
+                id_usuario__in=list_id_monitores, id_semestre=var_semestre.id, estado=True).values('id_estudiante')
+            list_estudiantes = estudiante.objects.filter(
+                id__in=list_id_estudiantes)
+            serializer_estudiantes = estudiante_serializer(
+                list_estudiantes, many=True)
             return Response(serializer_estudiantes.data)
 
         elif data_usuario_rol == "traer_todos_estudiantes":
 
-            list_id_programas = programa.objects.filter(id_sede=data_sede).values('id')
-            list_id_estudiantes = programa_estudiante.objects.filter(id_programa__in=list_id_programas).values('id_estudiante')
-            list_estudiantes = estudiante.objects.filter(id__in=list_id_estudiantes)
-            serializer_estudiantes = estudiante_serializer(list_estudiantes, many=True)
+            list_id_programas = programa.objects.filter(
+                id_sede=data_sede).values('id')
+            list_id_estudiantes = programa_estudiante.objects.filter(
+                id_programa__in=list_id_programas).values('id_estudiante')
+            list_estudiantes = estudiante.objects.filter(
+                id__in=list_id_estudiantes)
+            serializer_estudiantes = estudiante_serializer(
+                list_estudiantes, many=True)
             return Response(serializer_estudiantes.data)
 
             # serializer_estudiante = estudiante_serializer(estudiante.objects.all(), many=True)
             # return Response(serializer_estudiante.data)
 
         elif data_usuario_rol == "socioeducativo_reg" or data_usuario_rol == "socioeducativo" or data_usuario_rol == "dir_investigacion" or data_usuario_rol == "dir_academico" or data_usuario_rol == "super_ases":
-            list_id_programas = programa.objects.filter(id_sede=data_sede).values('id')
-            list_id_estudiantes = programa_estudiante.objects.filter(id_programa__in=list_id_programas).values('id_estudiante')
-            list_estudiantes = estudiante.objects.filter(id__in=list_id_estudiantes,estudiante_elegible=True)
-            serializer_estudiantes = estudiante_serializer(list_estudiantes, many=True)
+            list_id_programas = programa.objects.filter(
+                id_sede=data_sede).values('id')
+            list_id_estudiantes = programa_estudiante.objects.filter(
+                id_programa__in=list_id_programas).values('id_estudiante')
+            list_estudiantes = estudiante.objects.filter(
+                id__in=list_id_estudiantes, estudiante_elegible=True)
+            serializer_estudiantes = estudiante_serializer(
+                list_estudiantes, many=True)
             return Response(serializer_estudiantes.data)
 
         elif data_usuario_rol == "dir_programa":
-            obj_dir = usuario_rol.objects.filter(id_usuario=pk, id_semestre=var_semestre.id, estado="ACTIVO").values('id')
-            obj_dir_programa = dir_programa.objects.filter(id_usuario_rol=obj_dir[0]['id']).values()
-            list_id_estudiantes = programa_estudiante.objects.filter(id_programa=obj_dir_programa[0]['id_programa_id']).values('id_estudiante')
-            list_estudiantes = estudiante.objects.filter(id__in=list_id_estudiantes)
-            serializer_estudiantes = estudiante_serializer(list_estudiantes, many=True)
+            obj_dir = usuario_rol.objects.filter(
+                id_usuario=pk, id_semestre=var_semestre.id, estado="ACTIVO").values('id')
+            obj_dir_programa = dir_programa.objects.filter(
+                id_usuario_rol=obj_dir[0]['id']).values()
+            list_id_estudiantes = programa_estudiante.objects.filter(
+                id_programa=obj_dir_programa[0]['id_programa_id']).values('id_estudiante')
+            list_estudiantes = estudiante.objects.filter(
+                id__in=list_id_estudiantes)
+            serializer_estudiantes = estudiante_serializer(
+                list_estudiantes, many=True)
             return Response(serializer_estudiantes.data)
 
         elif data_usuario_rol == "vcd_academico":
-            obj_usuario_rol = usuario_rol.objects.filter(id_usuario=pk, id_semestre=var_semestre.id, estado="ACTIVO").values('id')
-            obj_facultad = vcd_academico.objects.filter(id_usuario_rol=obj_usuario_rol[0]['id']).values('id_facultad')
-            list_programas = programa.objects.filter(id_facultad = obj_facultad[0]['id_facultad']).values('id')
-            list_id_estudiantes = programa_estudiante.objects.filter(id_programa__in =list_programas).values('id_estudiante')
-            list_estudiantes = estudiante.objects.filter(id__in=list_id_estudiantes)
-            serializer_estudiantes = estudiante_serializer(list_estudiantes, many=True)
+            obj_usuario_rol = usuario_rol.objects.filter(
+                id_usuario=pk, id_semestre=var_semestre.id, estado="ACTIVO").values('id')
+            obj_facultad = vcd_academico.objects.filter(
+                id_usuario_rol=obj_usuario_rol[0]['id']).values('id_facultad')
+            list_programas = programa.objects.filter(
+                id_facultad=obj_facultad[0]['id_facultad']).values('id')
+            list_id_estudiantes = programa_estudiante.objects.filter(
+                id_programa__in=list_programas).values('id_estudiante')
+            list_estudiantes = estudiante.objects.filter(
+                id__in=list_id_estudiantes)
+            serializer_estudiantes = estudiante_serializer(
+                list_estudiantes, many=True)
             return Response(serializer_estudiantes.data)
-        
 
         elif data_usuario_rol == None:
             return Response("Comunicate con el administrador para que te asigne un rol", status=status.HTTP_400_BAD_REQUEST)
@@ -108,7 +138,6 @@ class estudiante_por_rol_viewsets(viewsets.ModelViewSet):
 
 class estudiante_filtros_viewsets(viewsets.ModelViewSet):
 
-    
     serializer_class = estudiante_serializer
     queryset = estudiante_serializer.Meta.model.objects.all()
     # permission_classes = (IsAuthenticated,)
@@ -132,55 +161,86 @@ class estudiante_filtros_viewsets(viewsets.ModelViewSet):
 
         if data_usuario_rol == "monitor":
             final_list_estudiantes = list()
-            list_id_estudiantes = asignacion.objects.filter(id_usuario=pk, id_semestre=var_semestre.id, estado=True).values('id_estudiante')
-            list_estudiantes = estudiante.objects.filter(id__in=list_id_estudiantes)
-            serializer_estudiantes = estudiante_serializer(list_estudiantes, many=True)
-            
+            list_id_estudiantes = asignacion.objects.filter(
+                id_usuario=pk, id_semestre=var_semestre.id, estado=True).values('id_estudiante')
+            list_estudiantes = estudiante.objects.filter(
+                id__in=list_id_estudiantes)
+            serializer_estudiantes = estudiante_serializer(
+                list_estudiantes, many=True)
+
         elif data_usuario_rol == "practicante":
             final_list_estudiantes = list()
-            list_id_monitores= usuario_rol.objects.filter(id_jefe=pk, id_semestre=var_semestre.id, estado="ACTIVO").values('id_usuario')
-            list_id_estudiantes = asignacion.objects.filter(id_usuario__in=list_id_monitores, id_semestre=var_semestre.id, estado=True).values('id_estudiante')
-            list_estudiantes = estudiante.objects.filter(id__in=list_id_estudiantes)
-            serializer_estudiantes = estudiante_serializer(list_estudiantes, many=True)
-            
+            list_id_monitores = usuario_rol.objects.filter(
+                id_jefe=pk, id_semestre=var_semestre.id, estado="ACTIVO").values('id_usuario')
+            list_id_estudiantes = asignacion.objects.filter(
+                id_usuario__in=list_id_monitores, id_semestre=var_semestre.id, estado=True).values('id_estudiante')
+            list_estudiantes = estudiante.objects.filter(
+                id__in=list_id_estudiantes)
+            serializer_estudiantes = estudiante_serializer(
+                list_estudiantes, many=True)
+
         elif data_usuario_rol == "profesional":
             final_list_estudiantes = list()
-            list_id_practicantes= usuario_rol.objects.filter(id_jefe=pk, id_semestre=var_semestre.id, estado="ACTIVO").values('id_usuario')
-            list_id_monitores= usuario_rol.objects.filter(id_jefe__in=list_id_practicantes, id_semestre=var_semestre.id, estado="ACTIVO").values('id_usuario')
-            list_id_estudiantes = asignacion.objects.filter(id_usuario__in=list_id_monitores, id_semestre=var_semestre.id, estado=True).values('id_estudiante')
-            list_estudiantes = estudiante.objects.filter(id__in=list_id_estudiantes)
-            serializer_estudiantes = estudiante_serializer(list_estudiantes, many=True)
+            list_id_practicantes = usuario_rol.objects.filter(
+                id_jefe=pk, id_semestre=var_semestre.id, estado="ACTIVO").values('id_usuario')
+            list_id_monitores = usuario_rol.objects.filter(
+                id_jefe__in=list_id_practicantes, id_semestre=var_semestre.id, estado="ACTIVO").values('id_usuario')
+            list_id_estudiantes = asignacion.objects.filter(
+                id_usuario__in=list_id_monitores, id_semestre=var_semestre.id, estado=True).values('id_estudiante')
+            list_estudiantes = estudiante.objects.filter(
+                id__in=list_id_estudiantes)
+            serializer_estudiantes = estudiante_serializer(
+                list_estudiantes, many=True)
 
         elif data_usuario_rol == "traer_todos_estudiantes":
             final_list_estudiantes = list()
-            list_id_programas = programa.objects.filter(id_sede=data_sede).values('id')
-            list_id_estudiantes = programa_estudiante.objects.filter(id_programa__in=list_id_programas).values('id_estudiante')
-            list_estudiantes = estudiante.objects.filter(id__in=list_id_estudiantes)
-            serializer_estudiantes = estudiante_serializer(list_estudiantes, many=True)
+            list_id_programas = programa.objects.filter(
+                id_sede=data_sede).values('id')
+            list_id_estudiantes = programa_estudiante.objects.filter(
+                id_programa__in=list_id_programas).values('id_estudiante')
+            list_estudiantes = estudiante.objects.filter(
+                id__in=list_id_estudiantes)
+            serializer_estudiantes = estudiante_serializer(
+                list_estudiantes, many=True)
 
         elif data_usuario_rol == "socioeducativo_reg" or data_usuario_rol == "socioeducativo" or data_usuario_rol == "dir_investigacion" or data_usuario_rol == "dir_academico" or data_usuario_rol == "super_ases":
             final_list_estudiantes = list()
-            list_id_programas = programa.objects.filter(id_sede=data_sede).values('id')
-            list_id_estudiantes = programa_estudiante.objects.filter(id_programa__in=list_id_programas).values('id_estudiante')
-            list_estudiantes = estudiante.objects.filter(id__in=list_id_estudiantes,estudiante_elegible=True)
-            serializer_estudiantes = estudiante_serializer(list_estudiantes, many=True)
+            list_id_programas = programa.objects.filter(
+                id_sede=data_sede).values('id')
+            list_id_estudiantes = programa_estudiante.objects.filter(
+                id_programa__in=list_id_programas).values('id_estudiante')
+            list_estudiantes = estudiante.objects.filter(
+                id__in=list_id_estudiantes, estudiante_elegible=True)
+            serializer_estudiantes = estudiante_serializer(
+                list_estudiantes, many=True)
 
         elif data_usuario_rol == "dir_programa":
             final_list_estudiantes = []
-            obj_dir = usuario_rol.objects.filter(id_usuario=pk, id_semestre=var_semestre.id, estado="ACTIVO").values('id')
-            obj_dir_programa = dir_programa.objects.filter(id_usuario_rol=obj_dir[0]['id']).values()
-            list_id_estudiantes = programa_estudiante.objects.filter(id_programa=obj_dir_programa[0]['id_programa_id']).values('id_estudiante')
-            list_estudiantes = estudiante.objects.filter(id__in=list_id_estudiantes)
-            serializer_estudiantes = estudiante_serializer(list_estudiantes, many=True)
+            obj_dir = usuario_rol.objects.filter(
+                id_usuario=pk, id_semestre=var_semestre.id, estado="ACTIVO").values('id')
+            obj_dir_programa = dir_programa.objects.filter(
+                id_usuario_rol=obj_dir[0]['id']).values()
+            list_id_estudiantes = programa_estudiante.objects.filter(
+                id_programa=obj_dir_programa[0]['id_programa_id']).values('id_estudiante')
+            list_estudiantes = estudiante.objects.filter(
+                id__in=list_id_estudiantes)
+            serializer_estudiantes = estudiante_serializer(
+                list_estudiantes, many=True)
 
         elif data_usuario_rol == "vcd_academico":
             final_list_estudiantes = []
-            obj_usuario_rol = usuario_rol.objects.filter(id_usuario=pk, id_semestre=var_semestre.id, estado="ACTIVO").values('id')
-            obj_facultad = vcd_academico.objects.filter(id_usuario_rol=obj_usuario_rol[0]['id']).values('id_facultad')
-            list_programas = programa.objects.filter(id_facultad = obj_facultad[0]['id_facultad']).values('id')
-            list_id_estudiantes = programa_estudiante.objects.filter(id_programa__in =list_programas).values('id_estudiante')
-            list_estudiantes = estudiante.objects.filter(id__in=list_id_estudiantes)
-            serializer_estudiantes = estudiante_serializer(list_estudiantes, many=True)
+            obj_usuario_rol = usuario_rol.objects.filter(
+                id_usuario=pk, id_semestre=var_semestre.id, estado="ACTIVO").values('id')
+            obj_facultad = vcd_academico.objects.filter(
+                id_usuario_rol=obj_usuario_rol[0]['id']).values('id_facultad')
+            list_programas = programa.objects.filter(
+                id_facultad=obj_facultad[0]['id_facultad']).values('id')
+            list_id_estudiantes = programa_estudiante.objects.filter(
+                id_programa__in=list_programas).values('id_estudiante')
+            list_estudiantes = estudiante.objects.filter(
+                id__in=list_id_estudiantes)
+            serializer_estudiantes = estudiante_serializer(
+                list_estudiantes, many=True)
 
         else:
             # Si el rol no coincide con ninguno de los casos anteriores, retornar lista vacía
@@ -193,26 +253,31 @@ class estudiante_filtros_viewsets(viewsets.ModelViewSet):
         estudiantes_ids = [data['id'] for data in serializer_estudiantes.data]
 
         # Obtener los datos relacionados a las condiciones de excepción de una vez
-        condiciones_excepcion = cond_excepcion.objects.filter(id__in=[data['id_cond_excepcion'] for data in serializer_estudiantes.data])
-
+        condiciones_excepcion = cond_excepcion.objects.filter(
+            id__in=[data['id_cond_excepcion'] for data in serializer_estudiantes.data])
 
         # Obtener los datos relacionados a los programas y estados de una vez
-        programas_estudiantes = programa_estudiante.objects.filter(id_estudiante__in=list_estudiantes)
-        programa_data = programa.objects.in_bulk(programas_estudiantes.values_list('id_programa_id', flat=True))
-        estado_data = estado_programa.objects.in_bulk(programas_estudiantes.values_list('id_estado_id', flat=True))
-        
-        sedes = sede.objects.in_bulk([programa_data[programa_id].id_sede_id for programa_id in programa_data])
+        programas_estudiantes = programa_estudiante.objects.filter(
+            id_estudiante__in=list_estudiantes)
+        programa_data = programa.objects.in_bulk(
+            programas_estudiantes.values_list('id_programa_id', flat=True))
+        estado_data = estado_programa.objects.in_bulk(
+            programas_estudiantes.values_list('id_estado_id', flat=True))
+
+        sedes = sede.objects.in_bulk(
+            [programa_data[programa_id].id_sede_id for programa_id in programa_data])
 
         # Obtener los datos relacionados con el último seguimiento de una vez
-        seguimientos_recientes = riesgo_individual.objects.filter(id_estudiante__in=estudiantes_ids).values('id_estudiante', 'riesgo_individual', 'riesgo_familiar', 'riesgo_academico', 'riesgo_economico', 'riesgo_vida_universitaria_ciudad')
-
+        seguimientos_recientes = riesgo_individual.objects.filter(id_estudiante__in=estudiantes_ids).values(
+            'id_estudiante', 'riesgo_individual', 'riesgo_familiar', 'riesgo_academico', 'riesgo_economico', 'riesgo_vida_universitaria_ciudad')
 
         for data_del_estudiante in serializer_estudiantes.data:
             # serializer_estudiante_2 = estudiante_serializer(i)
             estudiante_id = data_del_estudiante['id']
 
             try:
-                seguimiento_reciente = next((s for s in seguimientos_recientes if s['id_estudiante'] == estudiante_id), None)
+                seguimiento_reciente = next(
+                    (s for s in seguimientos_recientes if s['id_estudiante'] == estudiante_id), None)
                 # Crear un diccionario con los datos de riesgo del seguimiento
                 if seguimiento_reciente:
                     riesgo = {
@@ -224,11 +289,11 @@ class estudiante_filtros_viewsets(viewsets.ModelViewSet):
                     }
                 else:
                     riesgo = {
-                    'riesgo_individual': 'SIN RIESGO',
-                    'riesgo_familiar': 'SIN RIESGO',
-                    'riesgo_academico': 'SIN RIESGO',
-                    'riesgo_economico': 'SIN RIESGO',
-                    'riesgo_vida_universitaria_ciudad': 'SIN RIESGO'
+                        'riesgo_individual': 'SIN RIESGO',
+                        'riesgo_familiar': 'SIN RIESGO',
+                        'riesgo_academico': 'SIN RIESGO',
+                        'riesgo_economico': 'SIN RIESGO',
+                        'riesgo_vida_universitaria_ciudad': 'SIN RIESGO'
                     }
             except seguimiento_individual.DoesNotExist:
                 # Si no se encuentra ningún seguimiento para el estudiante especificado, devolver una respuesta vacía
@@ -241,14 +306,18 @@ class estudiante_filtros_viewsets(viewsets.ModelViewSet):
                 }
 
             try:
-                programa_del_estudiante = programas_estudiantes.filter(id_estudiante=data_del_estudiante['id']).first()
+                programa_del_estudiante = programas_estudiantes.filter(
+                    id_estudiante=data_del_estudiante['id']).first()
                 # print(programa_del_estudiante)
-                programa_estudiante_data = programa_estudiante.objects.filter(id_estudiante=data_del_estudiante['id']).values('id_programa', 'id_estado')
+                programa_estudiante_data = programa_estudiante.objects.filter(
+                    id_estudiante=data_del_estudiante['id']).values('id_programa', 'id_estado')
                 # print(programa_estudiante_data)
-                
-                cohorte_estudiante_data = cohorte_estudiante.objects.filter(id_estudiante=data_del_estudiante['id']).values('id_cohorte')
+
+                cohorte_estudiante_data = cohorte_estudiante.objects.filter(
+                    id_estudiante=data_del_estudiante['id']).values('id_cohorte')
                 # print(cohorte_estudiante_data)
-                cohorte_data = cohorte.objects.filter(id__in=cohorte_estudiante_data).values('id_number')
+                cohorte_data = cohorte.objects.filter(
+                    id__in=cohorte_estudiante_data).values('id_number')
                 # print(cohorte_data)
 
                 # dic_programa = {
@@ -259,37 +328,28 @@ class estudiante_filtros_viewsets(viewsets.ModelViewSet):
                 dic_programa = {
                     'programas': []
                 }
-                
-                dic_reg_academico = {
-                    'registro_academico': []
-                }
-                
+
                 for programa_ in programa_estudiante_data:
                     # Obtiene la información del programa académico
                     id_programa = programa_['id_programa']
-                    programa_info = programa_data.get(id_programa)  # Obtener información del programa
-                    
+                    # Obtener información del programa
+                    programa_info = programa_data.get(id_programa)
+
                     # Obtiene el estado del registro académico de cada programa
                     id_estado = programa_['id_estado']
-                    estado_info = estado_data.get(id_estado)  # Obtener información del estado
-                    
+                    # Obtener información del estado
+                    estado_info = estado_data.get(id_estado)
+
                     if programa_info:
                         dic_programa['programas'].append({
                             'id_programa': programa_data[id_programa].codigo_univalle,
                             'programa_academico': programa_data[id_programa].nombre,
                             'sede': sedes[programa_data[id_programa].id_sede_id].nombre,
                         })
-                        
-                    if estado_info:
-                        dic_reg_academico['registro_academico'].append({
-                            'estado': estado_info.nombre
-                        })          
-                   
-                
+
                 dic_cohorte = {
                     'cohorte': list(cohorte_data.values_list('id_number', flat=True))
                 }
-                
 
             except Exception as e:
                 print("Error en la consulta de programas")
@@ -298,30 +358,33 @@ class estudiante_filtros_viewsets(viewsets.ModelViewSet):
                     'id_programa': '',
                     'programa_academico': 'N/A',
                     'sede': 'N/A'
-                } 
-                dic_reg_academico = {
-                    'registro_academico': 'N/A'
                 }
-                
-                dic_cohorte = {   
+
+                dic_cohorte = {
                     'cohorte': 'N/A'
                 }
 
             try:
-                id_monitor_estudiante = asignacion.objects.filter(id_estudiante=data_del_estudiante['id'], estado=True,id_semestre=var_semestre.id).values('id_usuario')
-                data_monitor = User.objects.filter(id=id_monitor_estudiante[0]['id_usuario']).values('id','first_name','last_name')
-                consulta_jefe_monitor = usuario_rol.objects.filter(id_usuario=data_monitor[0]['id'],id_semestre=var_semestre.id, estado="ACTIVO").values('id_jefe')
-                data_practicante = User.objects.filter(id=consulta_jefe_monitor[0]['id_jefe']).values('id','first_name','last_name')
-                consulta_jefe_practicante = usuario_rol.objects.filter(id_usuario=data_practicante[0]['id'],id_semestre=var_semestre.id, estado="ACTIVO").values('id_jefe')
-                data_profesional = User.objects.filter(id=consulta_jefe_practicante[0]['id_jefe']).values('first_name','last_name')
+                id_monitor_estudiante = asignacion.objects.filter(
+                    id_estudiante=data_del_estudiante['id'], estado=True, id_semestre=var_semestre.id).values('id_usuario')
+                data_monitor = User.objects.filter(
+                    id=id_monitor_estudiante[0]['id_usuario']).values('id', 'first_name', 'last_name')
+                consulta_jefe_monitor = usuario_rol.objects.filter(
+                    id_usuario=data_monitor[0]['id'], id_semestre=var_semestre.id, estado="ACTIVO").values('id_jefe')
+                data_practicante = User.objects.filter(
+                    id=consulta_jefe_monitor[0]['id_jefe']).values('id', 'first_name', 'last_name')
+                consulta_jefe_practicante = usuario_rol.objects.filter(
+                    id_usuario=data_practicante[0]['id'], id_semestre=var_semestre.id, estado="ACTIVO").values('id_jefe')
+                data_profesional = User.objects.filter(
+                    id=consulta_jefe_practicante[0]['id_jefe']).values('first_name', 'last_name')
 
                 dic_asignaciones = {
-                    'asignacion_monitores':data_monitor[0]['first_name'] + " " + data_monitor[0]['last_name'],
+                    'asignacion_monitores': data_monitor[0]['first_name'] + " " + data_monitor[0]['last_name'],
                     'asignacion_practicante': data_practicante[0]['first_name'] + " " + data_practicante[0]['last_name'],
                     'asignacion_profesional': data_profesional[0]['first_name'] + " " + data_profesional[0]['last_name']
                 }
                 dic_estados = {
-                        'estado_ases': 'ACTIVO/A'
+                    'estado_ases': 'ACTIVO/A'
                 }
             except:
                 dic_asignaciones = {
@@ -330,24 +393,25 @@ class estudiante_filtros_viewsets(viewsets.ModelViewSet):
                     'asignacion_profesional': 'Sin Asignar'
                 }
                 dic_estados = {
-                        'estado_ases': 'INACTIVO/A'
+                    'estado_ases': 'INACTIVO/A'
                 }
                 # pass
 
             try:
-                cond_excepcion_data = [ce for ce in condiciones_excepcion if ce.id == data_del_estudiante['id_cond_excepcion']]
+                cond_excepcion_data = [
+                    ce for ce in condiciones_excepcion if ce.id == data_del_estudiante['id_cond_excepcion']]
                 dic_cond_excepcion = {
-                "condicion_excepcion": cond_excepcion_data[0].alias
+                    "condicion_excepcion": cond_excepcion_data[0].alias
                 }
 
             except:
                 dic_cond_excepcion = {
                     "condicion_excepcion": ''
-                }   
+                }
 
-            data = dict(data_del_estudiante, **riesgo, **dic_programa, **dic_estados, **
-                        dic_reg_academico, **dic_cohorte, **dic_asignaciones, **dic_cond_excepcion)
-    
+            data = dict(data_del_estudiante, **riesgo, **dic_programa, **dic_estados,
+                        **dic_cohorte, **dic_asignaciones, **dic_cond_excepcion)
+
             final_list_estudiantes.append(data)
             # print(data)
         return Response(final_list_estudiantes)
@@ -366,36 +430,42 @@ class get_cohortes_viewsets(viewsets.GenericViewSet):
 
         if data_usuario_rol == "monitor":
             final_list_estudiantes = list()
-            list_id_estudiantes = asignacion.objects.filter(id_usuario=pk, id_semestre=var_semestre.id, estado=True).values('id_estudiante')
-            list_estudiantes = estudiante.objects.filter(id__in=list_id_estudiantes)
-            serializer_estudiantes = estudiante_serializer(list_estudiantes, many=True)
-            
+            list_id_estudiantes = asignacion.objects.filter(
+                id_usuario=pk, id_semestre=var_semestre.id, estado=True).values('id_estudiante')
+            list_estudiantes = estudiante.objects.filter(
+                id__in=list_id_estudiantes)
+            serializer_estudiantes = estudiante_serializer(
+                list_estudiantes, many=True)
+
         estudiantes_ids = [data['id'] for data in serializer_estudiantes.data]
         # print("bfr fr loop")
         list_cohortes = []
         for data_del_estudiante in serializer_estudiantes.data:
             estudiante_id = data_del_estudiante['id']
             try:
-                cohorte_estudiante_data = cohorte_estudiante.objects.filter(id_estudiante=data_del_estudiante['id']).values('id_cohorte')
+                cohorte_estudiante_data = cohorte_estudiante.objects.filter(
+                    id_estudiante=data_del_estudiante['id']).values('id_cohorte')
                 # print(cohorte_estudiante_data)
-                cohorte_data = cohorte.objects.filter(id__in=cohorte_estudiante_data).values('id_number')
+                cohorte_data = cohorte.objects.filter(
+                    id__in=cohorte_estudiante_data).values('id_number')
                 # print(cohorte_data)
                 dic_cohorte = {
-                        'cohorte': cohorte_data[0]['id_number']
-                    }
+                    'cohorte': cohorte_data[0]['id_number']
+                }
             except:
-                dic_cohorte = {   
-                        'cohorte': 'N/A'
-                    }
-            
+                dic_cohorte = {
+                    'cohorte': 'N/A'
+                }
+
             data = dict(dic_cohorte)
             list_cohortes.append(data)
         # print(list_cohortes)
-        a_final_list_cohortes = list({v['cohorte']:v for v in list_cohortes}.values())
-        
+        a_final_list_cohortes = list(
+            {v['cohorte']: v for v in list_cohortes}.values())
+
         # print(a_final_list_cohortes)
 
-        new_cohorte  = list()
+        new_cohorte = list()
         new_cohorte_list = []
         cantidad_cohortes = 0
         last_list_cohortes = []
@@ -415,7 +485,6 @@ class get_cohortes_viewsets(viewsets.GenericViewSet):
             data = dict(new_cohorte_list)
             last_list_cohortes.append(data)
 
-        
         return Response(last_list_cohortes)
 
 
@@ -432,7 +501,7 @@ class estadisticas_monitorias_viewset(viewsets.ViewSet):
             .order_by('nombre')
             .values('id', 'nombre')
         )
-        return Response(data)   
+        return Response(data)
 
     @action(detail=False, methods=['post'], url_path='estadisticas_monitorias')
     def estadisticas_monitorias(self, request):
@@ -447,8 +516,10 @@ class estadisticas_monitorias_viewset(viewsets.ViewSet):
             # Filtrado inicial de monitorías (activas e inactivas)
             # ------------------------------
             filters = {}
-            if sede_id: filters['id_sede'] = sede_id
-            if semestre_id: filters['id_semestre'] = semestre_id
+            if sede_id:
+                filters['id_sede'] = sede_id
+            if semestre_id:
+                filters['id_semestre'] = semestre_id
             monitorias_queryset = monitoria_academica.objects.filter(**filters)
 
             # ------------------------------
@@ -457,8 +528,10 @@ class estadisticas_monitorias_viewset(viewsets.ViewSet):
             def get_semestre_fechas(sem_obj):
                 if not sem_obj:
                     return None, None
-                inicio = getattr(sem_obj.fecha_inicio, 'date', lambda: sem_obj.fecha_inicio)()
-                fin = getattr(sem_obj.fecha_fin, 'date', lambda: sem_obj.fecha_fin)()
+                inicio = getattr(sem_obj.fecha_inicio, 'date',
+                                 lambda: sem_obj.fecha_inicio)()
+                fin = getattr(sem_obj.fecha_fin, 'date',
+                              lambda: sem_obj.fecha_fin)()
                 return inicio, fin
 
             if semestre_id:
@@ -474,16 +547,20 @@ class estadisticas_monitorias_viewset(viewsets.ViewSet):
             # Filtrado por materia
             # ------------------------------
             if materia_filter:
-                monitorias_queryset = monitorias_queryset.filter(materia__icontains=materia_filter)
+                monitorias_queryset = monitorias_queryset.filter(
+                    materia__icontains=materia_filter)
 
-            monitoria_ids = list(monitorias_queryset.values_list('id', flat=True))
+            monitoria_ids = list(
+                monitorias_queryset.values_list('id', flat=True))
 
             # ------------------------------
             # Filtrado de asistencias dentro del rango de fechas
             # ------------------------------
-            asistencias_queryset = asistencia_model.objects.filter(id_monitoria__in=monitoria_ids)
+            asistencias_queryset = asistencia_model.objects.filter(
+                id_monitoria__in=monitoria_ids)
             if fecha_inicio and fecha_fin:
-                asistencias_queryset = asistencias_queryset.filter(fecha__range=[fecha_inicio, fecha_fin])
+                asistencias_queryset = asistencias_queryset.filter(
+                    fecha__range=[fecha_inicio, fecha_fin])
 
             # ------------------------------
             # Filtrar por facultad o programa sobre los estudiantes
@@ -492,18 +569,22 @@ class estadisticas_monitorias_viewset(viewsets.ViewSet):
                 facultad_ids = facultad.objects.filter(
                     Q(id=facultad_filter) | Q(nombre__icontains=facultad_filter)
                 ).values_list('id', flat=True)
-                programas_ids = programa.objects.filter(id_facultad__in=facultad_ids).values_list('id', flat=True)
+                programas_ids = programa.objects.filter(
+                    id_facultad__in=facultad_ids).values_list('id', flat=True)
             elif programa_filter:
                 # Intentar filtrar por ID primero (si es numérico)
                 try:
                     programa_id = int(programa_filter)
-                    programas_ids = programa.objects.filter(id=programa_id).values_list('id', flat=True)
+                    programas_ids = programa.objects.filter(
+                        id=programa_id).values_list('id', flat=True)
                 except (ValueError, TypeError):
                     # Si no es numérico, extraer el nombre sin la sigla (D) o (N) y filtrar por nombre
                     nombre_sin_sigla = programa_filter
                     # Remover patrones como " (D)" o " (N)" al final
-                    nombre_sin_sigla = re.sub(r'\s*\([DN]\)\s*$', '', nombre_sin_sigla).strip()
-                    programas_ids = programa.objects.filter(nombre__icontains=nombre_sin_sigla).values_list('id', flat=True)
+                    nombre_sin_sigla = re.sub(
+                        r'\s*\([DN]\)\s*$', '', nombre_sin_sigla).strip()
+                    programas_ids = programa.objects.filter(
+                        nombre__icontains=nombre_sin_sigla).values_list('id', flat=True)
             else:
                 programas_ids = None
 
@@ -511,36 +592,49 @@ class estadisticas_monitorias_viewset(viewsets.ViewSet):
                 estudiantes_ids = programa_estudiante.objects.filter(
                     id_programa__in=programas_ids
                 ).values_list('id_estudiante', flat=True)
-                asistencias_queryset = asistencias_queryset.filter(id_estudiante__in=estudiantes_ids)
+                asistencias_queryset = asistencias_queryset.filter(
+                    id_estudiante__in=estudiantes_ids)
 
             # ------------------------------
             # KPIs globales
             # ------------------------------
-            total_estudiantes = asistencias_queryset.values('id_estudiante').distinct().count()
-            total_asistencias = asistencias_queryset.filter(check_asistencia=True).count()
+            total_estudiantes = asistencias_queryset.values(
+                'id_estudiante').distinct().count()
+            total_asistencias = asistencias_queryset.filter(
+                check_asistencia=True).count()
 
             # ------------------------------
             # Estadísticas por materia (estudiantes y asistencias)
             # ------------------------------
-            materias_distintas = monitorias_queryset.values_list('materia', flat=True).distinct()
+            materias_distintas = monitorias_queryset.values_list(
+                'materia', flat=True).distinct()
             estudiantes_por_materia = []
             asistencias_por_materia = []
-            
-            for mat in materias_distintas:
-                monitorias_materia_ids = monitorias_queryset.filter(materia=mat).values_list('id', flat=True)
-                asistentes_qs = asistencia_model.objects.filter(id_monitoria__in=monitorias_materia_ids)
-                if fecha_inicio and fecha_fin:
-                    asistentes_qs = asistentes_qs.filter(fecha__range=[fecha_inicio, fecha_fin])
-                
-                count_estudiantes = asistentes_qs.values('id_estudiante').distinct().count()
-                count_asistencias = asistentes_qs.filter(check_asistencia=True).count()
 
-                estudiantes_por_materia.append({'materia': mat, 'estudiantes': count_estudiantes})
-                asistencias_por_materia.append({'materia': mat, 'asistencias': count_asistencias})
+            for mat in materias_distintas:
+                monitorias_materia_ids = monitorias_queryset.filter(
+                    materia=mat).values_list('id', flat=True)
+                asistentes_qs = asistencia_model.objects.filter(
+                    id_monitoria__in=monitorias_materia_ids)
+                if fecha_inicio and fecha_fin:
+                    asistentes_qs = asistentes_qs.filter(
+                        fecha__range=[fecha_inicio, fecha_fin])
+
+                count_estudiantes = asistentes_qs.values(
+                    'id_estudiante').distinct().count()
+                count_asistencias = asistentes_qs.filter(
+                    check_asistencia=True).count()
+
+                estudiantes_por_materia.append(
+                    {'materia': mat, 'estudiantes': count_estudiantes})
+                asistencias_por_materia.append(
+                    {'materia': mat, 'asistencias': count_asistencias})
 
             # Ordenar descendente por cantidad de asistentes
-            estudiantes_por_materia = sorted(estudiantes_por_materia, key=lambda x: x['estudiantes'], reverse=True)
-            asistencias_por_materia = sorted(asistencias_por_materia, key=lambda x: x['asistencias'], reverse=True)
+            estudiantes_por_materia = sorted(
+                estudiantes_por_materia, key=lambda x: x['estudiantes'], reverse=True)
+            asistencias_por_materia = sorted(
+                asistencias_por_materia, key=lambda x: x['asistencias'], reverse=True)
 
             # Estudiantes y asistencias por programa
             distribucion_estudiantes_programa = []
@@ -550,42 +644,51 @@ class estadisticas_monitorias_viewset(viewsets.ViewSet):
             # Programas de la sede
             # ------------------------------
             programas_distintos = programa.objects.all()
-            
+
             if sede_id:
-                programas_distintos = programas_distintos.filter(id_sede=sede_id)
-            
+                programas_distintos = programas_distintos.filter(
+                    id_sede=sede_id)
+
             # Filtrar por facultad si aplica
             if facultad_filter:
                 facultad_ids = facultad.objects.filter(
                     Q(id=facultad_filter) | Q(nombre__icontains=facultad_filter)
                 ).values_list('id', flat=True)
-                programas_distintos = programas_distintos.filter(id_facultad__in=facultad_ids)
+                programas_distintos = programas_distintos.filter(
+                    id_facultad__in=facultad_ids)
 
             # Filtrar por programa si aplica
             if programa_filter:
                 # Intentar filtrar por ID primero (si es numérico)
                 try:
                     programa_id = int(programa_filter)
-                    programas_distintos = programas_distintos.filter(id=programa_id)
+                    programas_distintos = programas_distintos.filter(
+                        id=programa_id)
                 except (ValueError, TypeError):
                     # Si no es numérico, extraer el nombre sin la sigla (D) o (N) y filtrar por nombre
-                    nombre_sin_sigla = re.sub(r'\s*\([DN]\)\s*$', '', programa_filter).strip()
-                    programas_distintos = programas_distintos.filter(nombre__icontains=nombre_sin_sigla)
-            
+                    nombre_sin_sigla = re.sub(
+                        r'\s*\([DN]\)\s*$', '', programa_filter).strip()
+                    programas_distintos = programas_distintos.filter(
+                        nombre__icontains=nombre_sin_sigla)
+
             for prog in programas_distintos:
                 # DIURNO / NOCTURNO → D / N
                 jornada_label = "D" if "DIURNA" in prog.jornada.upper() else "N"
-                nombre_programa = f"{prog.nombre} ({jornada_label})"                
+                nombre_programa = f"{prog.nombre} ({jornada_label})"
 
                 # Estudiantes asignados al programa
-                estudiantes_prog = programa_estudiante.objects.filter(id_programa=prog.id, traker=True).values_list('id_estudiante', flat=True)
-                asistencias_prog_qs = asistencias_queryset.filter(id_estudiante__in=estudiantes_prog)
+                estudiantes_prog = programa_estudiante.objects.filter(
+                    id_programa=prog.id, traker=True).values_list('id_estudiante', flat=True)
+                asistencias_prog_qs = asistencias_queryset.filter(
+                    id_estudiante__in=estudiantes_prog)
 
                 # Conteos
-                total_est_prog = asistencias_prog_qs.values('id_estudiante').distinct().count()
-                total_asist_prog = asistencias_prog_qs.filter(check_asistencia=True).count()
+                total_est_prog = asistencias_prog_qs.values(
+                    'id_estudiante').distinct().count()
+                total_asist_prog = asistencias_prog_qs.filter(
+                    check_asistencia=True).count()
 
-                if total_est_prog > 0:                    
+                if total_est_prog > 0:
 
                     distribucion_estudiantes_programa.append({
                         'programa': nombre_programa,
@@ -596,7 +699,7 @@ class estadisticas_monitorias_viewset(viewsets.ViewSet):
                         'programa': nombre_programa,
                         'valor': total_asist_prog
                     })
-                    
+
             # ------------------------------
             # Evolución temporal mensual
             # ------------------------------
@@ -608,8 +711,10 @@ class estadisticas_monitorias_viewset(viewsets.ViewSet):
             ).order_by('mes')
 
             # Construir línea de tiempo mensual completa del semestre
-            estudiantes_por_mes_map = {item['mes'].strftime('%Y-%m'): item['total_estudiantes'] for item in estudiantes_por_mes_qs if item['mes']}
-            asistencias_por_mes_map = {item['mes'].strftime('%Y-%m'): item['total_asistencias'] for item in asistencias_por_mes_qs if item['mes']}
+            estudiantes_por_mes_map = {item['mes'].strftime(
+                '%Y-%m'): item['total_estudiantes'] for item in estudiantes_por_mes_qs if item['mes']}
+            asistencias_por_mes_map = {item['mes'].strftime(
+                '%Y-%m'): item['total_asistencias'] for item in asistencias_por_mes_qs if item['mes']}
 
             estudiantes_por_mes = []
             asistencias_por_mes = []
@@ -621,8 +726,10 @@ class estadisticas_monitorias_viewset(viewsets.ViewSet):
                 cur = start_month
                 while cur <= end_month:
                     key = cur.strftime('%Y-%m')
-                    estudiantes_por_mes.append({'fecha': key, 'valor': estudiantes_por_mes_map.get(key, 0)})
-                    asistencias_por_mes.append({'fecha': key, 'valor': asistencias_por_mes_map.get(key, 0)})
+                    estudiantes_por_mes.append(
+                        {'fecha': key, 'valor': estudiantes_por_mes_map.get(key, 0)})
+                    asistencias_por_mes.append(
+                        {'fecha': key, 'valor': asistencias_por_mes_map.get(key, 0)})
                     # avanzar 1 mes
                     if cur.month == 12:
                         cur = cur.replace(year=cur.year + 1, month=1)
@@ -631,8 +738,10 @@ class estadisticas_monitorias_viewset(viewsets.ViewSet):
             else:
                 # fallback: usar solo los meses presentes en data
                 for k in sorted(set(list(estudiantes_por_mes_map.keys()) + list(asistencias_por_mes_map.keys()))):
-                    estudiantes_por_mes.append({'fecha': k, 'valor': estudiantes_por_mes_map.get(k, 0)})
-                    asistencias_por_mes.append({'fecha': k, 'valor': asistencias_por_mes_map.get(k, 0)})
+                    estudiantes_por_mes.append(
+                        {'fecha': k, 'valor': estudiantes_por_mes_map.get(k, 0)})
+                    asistencias_por_mes.append(
+                        {'fecha': k, 'valor': asistencias_por_mes_map.get(k, 0)})
 
             # ------------------------------
             # Materia con mayor / menor asistencia

--- a/front-end/src/components/componentes_generales/acordeon_usuarios.jsx
+++ b/front-end/src/components/componentes_generales/acordeon_usuarios.jsx
@@ -1,28 +1,22 @@
 /**
- * @file admin.jsx
+ * @file admin_usuarios.jsx
  * @version 1.0.0
- * @description Este archivo importa y renderiza los acordeones.
+ * @description Este archivo importa y renderiza el acordeón de usuarios.
  */
 
 import React, { useState, useEffect } from "react";
-import axios from "axios";
 import { Container, Button, Accordion, Modal, Form } from "react-bootstrap";
 import DataTable from "react-data-table-component";
 import DataTableExtensions from "react-data-table-component-extensions";
-import {
-  decryptTokenFromSessionStorage,
-  desencriptar,
-  desencriptarInt,
-} from "../../modulos/utilidades_seguridad/utilidades_seguridad.jsx";
+import { desencriptarInt } from "../../modulos/utilidades_seguridad/utilidades_seguridad.jsx";
 import { FaEdit } from "react-icons/fa";
 
 // Services
 import all_rols from "../../service/all_rols";
-import all_users_rols_service from "../../service/all_users_rol";
 import Create_user from "../../service/panel_admin/panel_admin_usuario_crear_usuario.js";
 import Read_user from "../../service/panel_admin/panel_admin_usuario_listar_usuarios.js";
 import Update_user from "../../service/panel_admin/panel_admin_usuario_actualizar_usuarios.js";
-import Deactivate_usar from "../../service/panel_admin/panel_admin_usuario_desactivar_usuario.js";
+import Deactivate_user from "../../service/panel_admin/panel_admin_usuario_desactivar_usuario.js";
 import Read_sedes from "../../service/panel_admin/panel_admin_sedes_listar_sedes.js";
 
 const SelectorUsuarios = () => {
@@ -47,7 +41,7 @@ const SelectorUsuarios = () => {
   const consultaAllUserRol = async () => {
     try {
       const semestre = desencriptarInt(
-        sessionStorage.getItem("id_semestre_actual")
+        sessionStorage.getItem("id_semestre_actual"),
       );
       const response = await Read_user.listar_usuarios({ semestre: semestre });
       // console.log(response);
@@ -104,14 +98,14 @@ const SelectorUsuarios = () => {
       // Si se cambia la sede
       if (name === "sede") {
         const currentUser = state.data_user_rol.find(
-          (user) => user.id === prevUser.id
+          (user) => user.id === prevUser.id,
         );
 
         // Solo asignar oldSede si aún no existe
         const oldSede =
           prevUser.oldSede !== undefined
             ? prevUser.oldSede
-            : currentUser?.sede ?? null;
+            : (currentUser?.sede ?? null);
 
         return {
           ...prevUser,
@@ -131,7 +125,7 @@ const SelectorUsuarios = () => {
   const handleSaveEdit = () => {
     // console.log(selectedUser);
     const semestre_actual = desencriptarInt(
-      sessionStorage.getItem("id_semestre_actual")
+      sessionStorage.getItem("id_semestre_actual"),
     );
     setSelectedUser((prevUser) => ({
       ...prevUser,
@@ -174,7 +168,7 @@ const SelectorUsuarios = () => {
     const usernamesToDeactivate = selectedRows.map((row) => {
       return { usuario: row.usuario };
     });
-    Deactivate_usar.desactivar_usuario(usernamesToDeactivate);
+    Deactivate_user.desactivar_usuario(usernamesToDeactivate);
     setSelectedRows([]); // Limpiar la selección después de desactivar
   };
 

--- a/front-end/src/components/componentes_generales/acordeon_usuarios_duplicados.jsx
+++ b/front-end/src/components/componentes_generales/acordeon_usuarios_duplicados.jsx
@@ -1,0 +1,189 @@
+/**
+ * @file acordeon_usuarios_duplicados.jsx
+ * @version 1.0.0
+ * @description Este archivo importa y renderiza los usuarios duplicados.
+ * @author @iMrStevenS2
+ * @date 27 de marzo del 2026
+ */
+
+import React, { useState, useEffect, useCallback } from "react";
+import axios from "axios";
+import { Container, Button, Accordion, Modal, Form } from "react-bootstrap";
+import DataTable from "react-data-table-component";
+import DataTableExtensions from "react-data-table-component-extensions";
+import {
+  decryptTokenFromSessionStorage,
+  desencriptar,
+  desencriptarInt,
+} from "../../modulos/utilidades_seguridad/utilidades_seguridad.jsx";
+import { FaEdit } from "react-icons/fa";
+import Swal from "sweetalert2";
+
+// Services
+import Read_user from "../../service/panel_admin/panel_admin_usuario_listar_usuarios_duplicados.js";
+import Delete_user from "../../service/panel_admin/panel_admin_usuario_eliminar_usuarios.js";
+
+const SelectorUsuarios = () => {
+  const [state, setState] = useState({
+    data_user_rol: [],
+  });
+
+  const [selectedRows, setSelectedRows] = useState([]);
+
+  const consultaAllUser = async () => {
+    try {
+      const semestre = desencriptarInt(
+        sessionStorage.getItem("id_semestre_actual"),
+      );
+      const response = await Read_user.listar_usuarios_duplicados();
+      // console.log(response);
+      if (response && Array.isArray(response)) {
+        setState({ ...state, data_user_rol: response });
+      }
+    } catch (error) {
+      console.error("Error al consultar usuarios con roles:", error);
+    }
+  };
+
+  const handleRowClick = (row) => {
+    setSelectedRows((prev) => {
+      const exists = prev.find((r) => r.id === row.id);
+
+      if (exists) {
+        return prev.filter((r) => r.id !== row.id); // deselecciona
+      } else {
+        return [...prev, row]; // selecciona
+      }
+    });
+  };
+
+  const handleDelete = () => {
+    // console.log(selectedRows);
+    if (selectedRows.length === 0) {
+      alert("Por favor, seleccione al menos un usuario para eliminar.");
+      return;
+    }
+
+    const tieneAsignaciones = selectedRows.some(
+      (row) => row.total_asignaciones > 0,
+    );
+
+    if (tieneAsignaciones) {
+      Swal.fire({
+        title: "Error",
+        text: "No se pueden eliminar usuarios con seguimientos realizados. Por favor, desactive el usuario en su lugar.",
+        icon: "error",
+        timer: 3000,
+        showConfirmButton: true,
+        confirmButtonText: "Aceptar",
+        confirmButtonColor: "#3085d6",
+      });
+      return;
+    }
+    const ids = selectedRows.map((row) => row.id);
+    Delete_user.eliminar_usuario({ ids });
+    setSelectedRows([]);
+  };
+
+  // Definición de las columnas de la tabla
+  const columnas = [
+    {
+      name: "ID",
+      selector: (row) => row.id,
+      sortable: true,
+      wrap: true,
+      grow: 0.2,
+    },
+    {
+      name: "USUARIO",
+      selector: (row) => row.username,
+      sortable: true,
+      wrap: true,
+      grow: 0.5,
+    },
+    {
+      name: "NOMBRES",
+      selector: (row) => row.first_name,
+      sortable: true,
+      wrap: true,
+      grow: 0.5,
+    },
+    {
+      name: "APELLIDOS",
+      selector: (row) => row.last_name,
+      sortable: true,
+      wrap: true,
+      grow: 0.5,
+    },
+    {
+      name: "EMAIL",
+      selector: (row) => row.email,
+      sortable: true,
+      wrap: true,
+      grow: 1.4,
+    },
+    {
+      name: "Seguimientos Realizados",
+      selector: (row) => row.total_asignaciones,
+      sortable: true,
+      wrap: true,
+      grow: 1,
+    },
+  ];
+
+  useEffect(() => {
+    consultaAllUser();
+  }, []);
+
+  const isRowSelected = useCallback(
+    (row) => selectedRows.some((r) => r.id === row.id),
+    [selectedRows],
+  );
+
+  return (
+    // TABLA DE USUARIOS
+    <Container>
+      <Accordion>
+        <Accordion.Item eventKey="1">
+          <Accordion.Header onClick={consultaAllUser}>
+            {
+              <span style={{ color: "black", fontWeight: "bold" }}>
+                Usuarios Duplicados
+              </span>
+            }
+          </Accordion.Header>
+          <Accordion.Body>
+            <DataTableExtensions
+              columns={columnas}
+              data={state.data_user_rol}
+              export={false}
+              print={false}
+              filterPlaceholder="Buscar usuarios..."
+            >
+              <DataTable
+                title="Usuarios Duplicados"
+                noDataComponent="Cargando Información."
+                pagination
+                selectableRows
+                selectableRowSelected={isRowSelected}
+                onRowClicked={handleRowClick}
+                striped
+                pointerOnHover
+                highlightOnHover
+              />
+            </DataTableExtensions>
+            <Button
+              variant="danger"
+              disabled={selectedRows.length === 0}
+              onClick={() => handleDelete()}
+            >
+              Eliminar Usuarios Seleccionados
+            </Button>
+          </Accordion.Body>
+        </Accordion.Item>
+      </Accordion>
+    </Container>
+  );
+};
+
+export default SelectorUsuarios;

--- a/front-end/src/modulos/admin/admin.jsx
+++ b/front-end/src/modulos/admin/admin.jsx
@@ -1,5 +1,5 @@
 /**
- * @file admin_usuarios.jsx
+ * @file admin.jsx
  * @version 1.0.0
  * @description modulo para CRUD de los usuarios.
  * @author Valentina Salamanca
@@ -24,8 +24,9 @@ import SelectorProgramas from "../../components/componentes_generales/acordeon_p
 import SelectorSemestres from "../../components/componentes_generales/acordeon_semestres.jsx";
 import SelectorTratamiento from "../../components/componentes_generales/acordeon_tratamiento_datos.jsx";
 import SelectorTratamientoTemporal from "../../components/componentes_generales/acordeon_tratamiento_datos_temporal.jsx";
+import SelectorUsuariosDuplicados from "../../components/componentes_generales/acordeon_usuarios_duplicados.jsx";
 
-const Gestion_usuario_roles = () => {
+const Gestion_usuarios_duplicados = () => {
   // Desencriptar los permisos del usuario desde el sessionStorage
   const userRole = desencriptar(sessionStorage.getItem("permisos"));
 
@@ -41,6 +42,7 @@ const Gestion_usuario_roles = () => {
           </Row>
           <Row className="rowJustFlex_usuario_rol2">
             <SelectorUsuarios />                {/* CONECTADO */}
+            <SelectorUsuariosDuplicados />       {/* CONECTADO */}
             <SelectorEstudiantes />             {/* CONECTADO */}
             <SelectorRoles />                   {/* CONECTADO */}
             <SelectorPermisos />                {/* CONECTADO */}
@@ -64,4 +66,4 @@ const Gestion_usuario_roles = () => {
   );
 };
 
-export default Gestion_usuario_roles;
+export default Gestion_usuarios_duplicados;

--- a/front-end/src/modulos/reportes/reporte.jsx
+++ b/front-end/src/modulos/reportes/reporte.jsx
@@ -299,9 +299,7 @@ const Reporte = () => {
     var key =
       item.value === "programa_academico"
         ? "csv_programa_academico"
-        : item.value === "registro_academico"
-          ? "csv_registro_academico"
-          : item.value;
+        : item.value;
     csv_headers.push({ label: label, key: key });
   };
 
@@ -337,17 +335,6 @@ const Reporte = () => {
               (programa) =>
                 `${programa.id_programa}, ${programa.programa_academico}, ${programa.sede}`,
             )
-            .join(" | ");
-        },
-      });
-    } else if (item.name === "Registro Académico") {
-      schema.push({
-        column: item.name,
-        type: tipo,
-        value: (student) => {
-          if (!Array.isArray(student.registro_academico)) return "Sin datos";
-          return student.registro_academico
-            .map((registro_acad) => registro_acad.estado)
             .join(" | ");
         },
       });
@@ -459,19 +446,13 @@ const Reporte = () => {
     {
       name: "Registro Académico",
       value: "registro_academico",
-      selector: (row) => {
-        // Verifica si row.registro_academico existe y es un array antes de usar .map()
-        if (!Array.isArray(row.registro_academico)) return "Sin datos";
-
-        return row.registro_academico
-          .map((registro_acad) => registro_acad.estado)
-          .join(" | ");
-      },
+      selector: (row) => (row.es_academico == true ? "ACTIVO" : "INACTIVO"),
       sortable: true,
       isCheck: false,
       wrap: true,
     },
   ];
+
   // Filtro por programa y sede
   const filtros_Academico = [
     // {
@@ -681,30 +662,13 @@ const Reporte = () => {
     }
     // BÚSQUEDA INDIVIDUAL POR FILTRO: REGISTRO
     if (e.target.name === "Registro Académico") {
-      const data_filtered = filtered.filter(
-        (row) =>
-          Array.isArray(row.registro_academico) &&
-          row.registro_academico.some((registro_acad) =>
-            registro_acad.estado
-              .toLowerCase()
-              .includes(e.target.value.toLowerCase()),
-          ),
+      const data_filtered = filtered.filter((row) =>
+        row.es_academico.toLowerCase().includes(e.target.value.toLowerCase()),
       );
-
       const filtered_data =
         data_filtered.length > 0 ? data_filtered : empty_stuff;
       setFiltered(filtered_data);
     }
-    // BÚSQUEDA INDIVIDUAL POR FILTRO: ACADÉMICO
-    // if (e.target.name === "Código programa académico") {
-    // //   const data_filtered = filtered.filter((row) =>
-    // //     row.id_programa.toString().includes(e.target.value.toLowerCase())
-    // //   );
-    // //   const filtered_data =
-    // //     data_filtered.length > 0 ? data_filtered : empty_stuff;
-    // //   setFiltered(filtered_data);
-    // }
-
     // BÚSQUEDA INDIVIDUAL POR FILTRO: NOMBRE ACADEMICO
     if (e.target.name === "Programa académico") {
       const filtro = e.target.value.toLowerCase(); // Convertimos a minúsculas para hacer la búsqueda insensible a mayúsculas.
@@ -1800,10 +1764,6 @@ const Reporte = () => {
                 `${programa.id_programa}, ${programa.programa_academico}, ${programa.sede}`,
             )
             .join(" | ") // Usamos `|` en lugar de `,` para separar mejor los programas
-        : "Sin datos",
-    csv_registro_academico:
-      Array.isArray(row.registro_academico) && row.registro_academico.length > 0
-        ? row.registro_academico.map((item) => item.estado).join(" | ")
         : "Sin datos",
   }));
 

--- a/front-end/src/service/panel_admin/panel_admin_usuario_eliminar_usuarios.js
+++ b/front-end/src/service/panel_admin/panel_admin_usuario_eliminar_usuarios.js
@@ -4,7 +4,7 @@
  * @description Service para eliminar un usuario existente mediante el panel del administrador.
  * @author @iMrStevenS2
  * @contact steven.bernal@correounivalle.edu.co
- * @date 29 de Abril del 2025
+ * @date 27 de marzo del 2026
  */
 
 import axios from "axios";
@@ -25,14 +25,27 @@ const eliminar_usuario = async (data) => {
       if (response.status === 200) {
         Swal.fire({
           title: "Operación exitosa",
-          text: response.data.mensaje,
+          html: `
+            <p><b>Eliminados:</b> ${response.data.eliminados
+              .map((u) => `ID: ${u.id} - ${u.username}`)
+              .join("<br>")}</p>
+
+            <p><b>No eliminados:</b> ${response.data.bloqueados
+              .map((u) => `ID: ${u.id} - ${u.username}`)
+              .join("<br>")}</p>
+
+          <p> Total eliminados:${response.data.total_eliminados}</p>
+          <p> Total bloqueados:${response.data.total_bloqueados}</p>
+          `,
           icon: "success",
-          timer: 2500,
-          showConfirmButton: false,
+          //   timer: 2500,
+          showConfirmButton: true,
+          confirmButtonText: "Aceptar",
+          confirmButtonColor: "#3085d6",
         });
-        setTimeout(() => {
-          window.location.reload();
-        }, 1000);
+        // setTimeout(() => {
+        //   window.location.reload();
+        // }, 1000);
       } else if (response.status === 400) {
         Swal.fire({
           title: "Error",

--- a/front-end/src/service/panel_admin/panel_admin_usuario_listar_usuarios_duplicados.js
+++ b/front-end/src/service/panel_admin/panel_admin_usuario_listar_usuarios_duplicados.js
@@ -1,0 +1,40 @@
+/**
+ * @file panel_admin_usuario_listar_usuarios_duplicados.js
+ * @version 1.0.0
+ * @description Service para listar los usuarios duplicados registrados mediante el panel del administrador.
+ * @author @iMrStevenS2
+ * @contact steven.bernal@correounivalle.edu.co
+ * @date 27 de Marzo del 2025
+ */
+
+import axios from "axios";
+import {
+  decryptTokenFromSessionStorage,
+  desencriptar,
+} from "../../modulos/utilidades_seguridad/utilidades_seguridad.jsx";
+import Swal from "sweetalert2";
+
+const listar_usuarios_duplicados = async (data) => {
+  const config = {
+    Authorization: "Bearer " + decryptTokenFromSessionStorage(),
+  };
+  const url_axios = `${process.env.REACT_APP_API_URL}/admin_ases/panel_admin_usuario/listar_usuarios_duplicados/`;
+
+  try {
+    const response = await axios.post(url_axios, data, { headers: config });
+    return response.data;
+  } catch (error) {
+    Swal.fire({
+      title: "Error",
+      text: "No se pudo listar los usuarios. Por favor, inténtelo de nuevo más tarde.",
+      icon: "error",
+      timer: 1500,
+      showConfirmButton: true,
+      confirmButtonText: "Aceptar",
+      confirmButtonColor: "#3085d6",
+    });
+    return false;
+  }
+};
+
+export default { listar_usuarios_duplicados };


### PR DESCRIPTION
* Se crea una vista para gestionar la eliminación de usuarios duplicados qué no tienen seguimientos individuales realizados.
* Se cambia el valor de registro académico para representar es_academico de la base de datos.