### PR TITLE
Implementación de eliminación masiva de firmas temporales

### DIFF
--- a/back-end/modulo_formularios_externos/views.py
+++ b/back-end/modulo_formularios_externos/views.py
@@ -362,6 +362,13 @@ class firma_temp_viewsets(viewsets.GenericViewSet):
       
             estudiantes_dict = {e.num_doc: e for e in estudiantes}
 
+            documentos_con_firma = set(
+                estudiante.objects.filter(
+                    num_doc__in=documentos,
+                    firma_existe=True
+                ).values_list('num_doc', flat=True)
+            )
+
             with transaction.atomic():
 
                 for firma_temp in firmas_temporales:
@@ -388,6 +395,10 @@ class firma_temp_viewsets(viewsets.GenericViewSet):
                         contador_firmas_creadas += 1
                         firma_temp.delete()
 
+                    elif documento in documentos_con_firma:
+                        firma_temp.delete()
+                        contador_firmas_creadas += 1
+
                     else:
                         firmas_no_creadas += 1
 
@@ -404,3 +415,26 @@ class firma_temp_viewsets(viewsets.GenericViewSet):
                 {'Respuesta': f'Error al procesar las firmas temporales: {str(e)}'},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR
             )
+        
+
+    @action(detail=False, methods=['delete'], url_path='eliminar_firmas_seleccionadas', permission_classes=[IsAuthenticated])
+    def eliminarFirmastemporales(self, request):
+        values = request.data.get('values')
+        
+        if not values:
+            return Response({'error': 'No se enviaron documentos a eliminar'}, status=status.HTTP_400_BAD_REQUEST)
+
+        #traemos las firmas que tengas los documentos de values
+        firmas = firma_tratamiento_datos_temp.objects.filter(documento__in = values)
+
+        cantidad_firmas = firmas.count()
+
+        # eliminamos las firmas en cuestion
+        if firmas:
+            firmas.delete()
+        else:
+            return Response({'firmas_eliminadas': 0,
+                         'mensaje': "Error del servidor al momento de eliminar las firmas."}, status=status.HTTP_500_INTERNAL_SERVER_ERROR )
+
+        return Response({'firmas_eliminadas': cantidad_firmas,
+                         'mensaje': "Firmas temporales eliminadas correctamente"}, status=status.HTTP_200_OK )

--- a/back-end/modulo_usuario_rol/views.py
+++ b/back-end/modulo_usuario_rol/views.py
@@ -684,15 +684,15 @@ class info_estudiantes_sin_seguimientos_viewsets(viewsets.ModelViewSet):
 
         for data_del_estudiante in serializer_estudiantes.data:
 
-            #traemos la corte del estudiante
-            cohorte_data = cohorte_estudiante.objects.filter(
+            cohortes_data = cohorte_estudiante.objects.filter(
                 id_estudiante=data_del_estudiante['id']
-            ).select_related('id_cohorte').first()
+            ).select_related('id_cohorte')
 
-            # si el estudiante no tiene una cohorte asignada, se asigna un valor por defecto
-            cohorte_nombre = "Sin cohorte"
-            if cohorte_data and cohorte_data.id_cohorte:
-                cohorte_nombre = cohorte_data.id_cohorte.id_number
+            cohorte_nombres = ", ".join([
+                c.id_cohorte.id_number 
+                for c in cohortes_data 
+                if c.id_cohorte
+            ]) or "Sin cohorte"
             
             # Conteos (estos siempre aplican)
             count_seguimientos = seguimiento_individual.objects.filter(
@@ -753,7 +753,7 @@ class info_estudiantes_sin_seguimientos_viewsets(viewsets.ModelViewSet):
             datos = {
                 'id': data_del_estudiante['id'],
                 'cod_univalle': data_del_estudiante['cod_univalle'],
-                'cohorte': cohorte_nombre,
+                'cohorte': cohorte_nombres,
                 'cedula': data_del_estudiante['num_doc'],
                 'nombres': data_del_estudiante['nombre'],
                 'apellidos': data_del_estudiante['apellido'],

--- a/back-end/modulo_usuario_rol/views.py
+++ b/back-end/modulo_usuario_rol/views.py
@@ -692,7 +692,7 @@ class info_estudiantes_sin_seguimientos_viewsets(viewsets.ModelViewSet):
             # si el estudiante no tiene una cohorte asignada, se asigna un valor por defecto
             cohorte_nombre = "Sin cohorte"
             if cohorte_data and cohorte_data.id_cohorte:
-                cohorte_nombre = cohorte_data.id_cohorte.nombre
+                cohorte_nombre = cohorte_data.id_cohorte.id_number
             
             # Conteos (estos siempre aplican)
             count_seguimientos = seguimiento_individual.objects.filter(

--- a/front-end/src/components/componentes_generales/acordeon_tratamiento_datos_temporal.jsx
+++ b/front-end/src/components/componentes_generales/acordeon_tratamiento_datos_temporal.jsx
@@ -11,6 +11,7 @@ import React, { useState, useEffect } from "react";
 import { Container, Button, Accordion } from "react-bootstrap";
 import DataTable from "react-data-table-component";
 import DataTableExtensions from "react-data-table-component-extensions";
+import Swal from "sweetalert2";
 
 import Read_tratamientos_temporales from "../../service/panel_admin/panel_admin_firma_tratamiento_datos_temporales_listar_tratamientos_temporales.js";
 import Delete_tratamientos_temporales from "../../service/panel_admin/panel_admin_firma_tratamiento_datos_temporales_eliminar_tratamientos_temporales.js";
@@ -22,6 +23,8 @@ const SelectorTratamientoTemporal = () => {
     filas_seleccionadas: [],
   });
 
+  
+
 
   const handleRowsSeleccionadas = ({ selectedRows }) => {
     setState((prevState) => ({
@@ -31,27 +34,42 @@ const SelectorTratamientoTemporal = () => {
   };
 
   const eliminarTratamientosSeleccionados = async () => {
-    try {
-      const ids = state.filas_seleccionadas.map((row) => row.num_doc);
-      console.log("IDs a eliminar:", ids);
-      const response = await Delete_tratamientos_temporales.eliminar_firmas_temporales({values : ids});
-      if (response) {
-        // eliminamos las filas seleccionadas del estado local para actualizar la tabla inmediatamente
-        setState((prevState) => ({
-          ...prevState,
-          filas_seleccionadas: [], 
-        }));
+    const result = await Swal.fire({
+      title: '¿Estas seguro de eliminar los registros seleccionados?',
+      text: "No es posible desacer esta accion",
+      icon: 'warning',
+      showCancelButton: true,
+      confirmButtonColor: '#3085d6',
+      cancelButtonColor: '#d33',
+      confirmButtonText: 'Eliminar registros'
+    });
 
-        // esperamos un momento para asegurarnos de que el backend haya procesado la eliminación antes de volver a consultar los datos
-        setTimeout(() => {
-          consultaAllTratamientosTemporales();
-        }, 1000);
-        
-      } else {
-        console.error("No se pudieron eliminar los tratamientos seleccionados.");
+    if (result.isConfirmed) {
+
+      Swal.fire({
+        title: 'Eliminando registros...',
+        text: 'Por favor espera',
+        allowOutsideClick: false,
+        allowEscapeKey: false,
+        showConfirmButton: false,
+        didOpen: () => {
+          Swal.showLoading();
+        }
+      });
+
+      try {
+        const ids = state.filas_seleccionadas.map((row) => row.num_doc);
+
+        const response = await Delete_tratamientos_temporales.eliminar_firmas_temporales({ values: ids });
+
+        if (response) {
+          setState((prevState) => ({ ...prevState, filas_seleccionadas: [] }));
+          await consultaAllTratamientosTemporales();
+        }
+
+      } catch (error) {
+        console.error("Error al eliminar tratamientos:", error);
       }
-    } catch (error) {
-      console.error("Error al eliminar tratamientos:", error);
     }
   };
 
@@ -149,7 +167,7 @@ const SelectorTratamientoTemporal = () => {
             >
               
               <DataTable
-                title="Tratamiento de Datos de Estudiantes"
+                title="Tratamiento de Datos temporales de Estudiantes"
                 noDataComponent="Cargando Información."
                 pagination
                 striped
@@ -162,6 +180,8 @@ const SelectorTratamientoTemporal = () => {
             <Button variant="primary" onClick={(e) => handleUpdateData()}>
               Verificar Consentimientos
             </Button>
+
+
             <Button
               variant="danger"
               disabled={state.filas_seleccionadas.length === 0}  

--- a/front-end/src/components/componentes_generales/acordeon_tratamiento_datos_temporal.jsx
+++ b/front-end/src/components/componentes_generales/acordeon_tratamiento_datos_temporal.jsx
@@ -13,12 +13,47 @@ import DataTable from "react-data-table-component";
 import DataTableExtensions from "react-data-table-component-extensions";
 
 import Read_tratamientos_temporales from "../../service/panel_admin/panel_admin_firma_tratamiento_datos_temporales_listar_tratamientos_temporales.js";
+import Delete_tratamientos_temporales from "../../service/panel_admin/panel_admin_firma_tratamiento_datos_temporales_eliminar_tratamientos_temporales.js";
 import Update_tratamientos from "../../service/panel_admin/panel_admin_firma_tratamiento_datos_temporales_actualizar_tratamientos_temporales.js";
 
 const SelectorTratamientoTemporal = () => {
   const [state, setState] = useState({
     data_tratamientos: [],
+    filas_seleccionadas: [],
   });
+
+
+  const handleRowsSeleccionadas = ({ selectedRows }) => {
+    setState((prevState) => ({
+      ...prevState,
+      filas_seleccionadas: selectedRows,
+    }));
+  };
+
+  const eliminarTratamientosSeleccionados = async () => {
+    try {
+      const ids = state.filas_seleccionadas.map((row) => row.num_doc);
+      console.log("IDs a eliminar:", ids);
+      const response = await Delete_tratamientos_temporales.eliminar_firmas_temporales({values : ids});
+      if (response) {
+        // eliminamos las filas seleccionadas del estado local para actualizar la tabla inmediatamente
+        setState((prevState) => ({
+          ...prevState,
+          filas_seleccionadas: [], 
+        }));
+
+        // esperamos un momento para asegurarnos de que el backend haya procesado la eliminación antes de volver a consultar los datos
+        setTimeout(() => {
+          consultaAllTratamientosTemporales();
+        }, 1000);
+        
+      } else {
+        console.error("No se pudieron eliminar los tratamientos seleccionados.");
+      }
+    } catch (error) {
+      console.error("Error al eliminar tratamientos:", error);
+    }
+  };
 
   const consultaAllTratamientosTemporales = async () => {
     try {
@@ -112,16 +147,28 @@ const SelectorTratamientoTemporal = () => {
               print={false}
               filterPlaceholder="Buscar firma de estudiante..."
             >
+              
               <DataTable
                 title="Tratamiento de Datos de Estudiantes"
                 noDataComponent="Cargando Información."
                 pagination
                 striped
+                selectableRows
+                selectableRowsHighlight
+                onSelectedRowsChange={handleRowsSeleccionadas}
               />
             </DataTableExtensions>
             <hr />
             <Button variant="primary" onClick={(e) => handleUpdateData()}>
               Verificar Consentimientos
+            </Button>
+            <Button
+              variant="danger"
+              disabled={state.filas_seleccionadas.length === 0}  
+              className="ms-2"
+              onClick={(e) => eliminarTratamientosSeleccionados()}  
+            >
+              Eliminar seleccionadas ({state.filas_seleccionadas.length})
             </Button>
           </Accordion.Body>
         </Accordion.Item>

--- a/front-end/src/service/panel_admin/panel_admin_firma_tratamiento_datos_temporales_eliminar_tratamientos_temporales.js
+++ b/front-end/src/service/panel_admin/panel_admin_firma_tratamiento_datos_temporales_eliminar_tratamientos_temporales.js
@@ -1,0 +1,56 @@
+/**
+ * @file panel_admin_firma_tratamiento_datos_temporales_eliminar_tratamientos_temporales.js
+ * @version 1.0.0
+ * @description Service para Eliminar los tratamientos de datos temporales de los estudiantes mediante el panel del administrador.
+ * @author @PabloBecerraDev
+ * @contact pablo.becerra@correounivalle.edu.co
+ * @date 2026-04-27
+ */
+
+import axios from "axios";
+import {
+  decryptTokenFromSessionStorage,
+  desencriptar,
+} from "../../modulos/utilidades_seguridad/utilidades_seguridad.jsx";
+import Swal from "sweetalert2";
+
+
+const eliminar_firmas_temporales = async (data) => {
+
+    const config = {
+        Authorization: "Bearer " + decryptTokenFromSessionStorage(),
+    };
+
+    const url_axios = `${process.env.REACT_APP_API_URL}/formularios_externos/firma_tratamiento_datos_temp/eliminar_firmas_seleccionadas/`;
+
+    try{
+        const response = await axios.delete(url_axios, {data: data, headers: config});
+        if (response.status == 200) {
+            Swal.fire({
+                title: "Operación exitosa",
+                html: `
+                <p><strong>Firmas eliminadas:</strong> ${response.data.firmas_eliminadas}</p>
+                <p> ${response.data.mensaje}</p>`,
+                icon: "success",
+                timer: 2500,
+                showConfirmButton: true,
+                    })
+            return response.data
+        }
+
+    }catch(error){
+        console.error("Error en la operación:", error);
+        Swal.fire({
+            title: "Error",
+            text: "No se pudo eliminar las firmas seleccionadas. Por favor, inténtelo de nuevo más tarde.",
+            icon: "error",
+            timer: 1500,
+            showConfirmButton: true,
+            confirmButtonText: "Aceptar",
+            confirmButtonColor: "#3085d6",
+        });
+        return false;
+    }
+};
+
+export default {eliminar_firmas_temporales};


### PR DESCRIPTION
Se implementó la funcionalidad que permite al administrador seleccionar y eliminar múltiples firmas temporales directamente desde la tabla del panel.

Cambios realizados

Backend

Se creó un endpoint para la eliminación masiva de firmas temporales con sus respectivos permisos de acceso.
El endpoint recibe los números de documento de los registros seleccionados y los elimina correctamente.

Frontend

Se agregaron checkboxes a los registros de la tabla para permitir la selección múltiple.
Se implementó un modal de confirmación antes de ejecutar la eliminación para evitar acciones accidentales.
Se agregó un spinner de carga que permanece activo hasta que el proceso de eliminación se complete.

Closes #292